### PR TITLE
docs: align API docs with agent standard

### DIFF
--- a/docs/developers/apis.md
+++ b/docs/developers/apis.md
@@ -8,6 +8,30 @@ Public REST endpoints for querying JustLend DAO protocol state: lending markets,
 - **Machine‑readable spec:** [`justlend_apis.yaml`](./apis/justlend_apis.yaml) (OpenAPI 3.1). Importable into Swagger UI, Postman, Insomnia, or any LLM tool.
 - **Rate limits:** The public service is unauthenticated and may throttle abusive traffic. Keep `pageSize <= 1000`, cache stable metadata such as jToken lists, and retry `429` / `5xx` responses with exponential backoff.
 
+## Quick start
+
+Run this read-only request to verify connectivity and inspect the current JustLend market list:
+
+```bash
+curl -sS https://openapi.just.network/lend/jtoken
+```
+
+Expected result:
+
+```json
+{
+  "code": 0,
+  "message": "SUCCESS",
+  "data": {
+    "tokenList": [
+      { "symbol": "jTRX", "underlyingSymbol": "TRX" }
+    ]
+  }
+}
+```
+
+For integrations, import the OpenAPI schema from [`apis/justlend_apis.yaml`](./apis/justlend_apis.yaml), then start with `GET /lend/jtoken` for market metadata and `GET /lend/account?addresses={wallet}` for a user's positions.
+
 ---
 
 ## 1. Conventions
@@ -101,6 +125,15 @@ The public API is designed for read-only integrations and AI agents. It is not a
 - Avoid tight polling loops. Market dashboards normally do not need sub-second refreshes.
 - On `429` or transient `5xx`, retry with exponential backoff and jitter. Start around 1 second and cap retries to avoid request storms.
 - If you need sustained high-volume access, contact the JustLend team before production launch.
+
+### 1.8 Versioning and compatibility
+
+The OpenAPI `info.version` is the documentation schema version. The HTTP API is read-only and backward-compatible unless an endpoint or field is explicitly marked otherwise.
+
+- Existing fields may be extended with new optional fields. Clients should ignore unknown fields.
+- Field removals, type changes, or semantic changes require a documentation version update and deprecation note before rollout.
+- Legacy fields can remain documented for compatibility. For example, `reserse` is preserved as returned by the service and should be read as `reserves`.
+- When the rendered page and OpenAPI YAML differ, treat [`apis/justlend_apis.yaml`](./apis/justlend_apis.yaml) as the source of truth for request and response shapes.
 
 ---
 

--- a/docs/developers/apis/justlend_apis.yaml
+++ b/docs/developers/apis/justlend_apis.yaml
@@ -1,4 +1,8 @@
 openapi: 3.1.0
+x-schema-version: '1.0.0'
+x-compatibility:
+    policy: Backward-compatible optional fields may be added without notice. Field removals, type changes, or semantic changes require a documentation version update and deprecation note.
+    sourceOfTruth: https://docs.justlend.org/developers/apis/justlend_apis.yaml
 x-rate-limit:
     authentication: none
     pageSizeMax: 1000
@@ -7,6 +11,13 @@ info:
     title: JustLend DAO API
     version: '1.0.0'
     summary: Public read‑only API for JustLend DAO protocol data.
+    termsOfService: https://justlend.org/docs/JustLend_Terms_of_Use_en.pdf
+    contact:
+        name: JustLend DAO
+        url: https://support.justlend.org/
+    license:
+        name: Documentation license and terms
+        url: https://justlend.org/docs/JustLend_Terms_of_Use_en.pdf
     description: |
         Public REST endpoints for querying JustLend DAO protocol state:
         lending markets, user positions, liquidation risk, USDD supply‑mining
@@ -26,6 +37,9 @@ info:
         * **Pagination** — `pageNo` is 1‑based, default `1`. `pageSize` default `10`, max `1000`.
         * **Rate limits** — public unauthenticated traffic may be throttled. Cache stable metadata and retry `429` / transient `5xx` with exponential backoff and jitter.
         * **Errors** — non‑zero `code` plus an RFC 7807 body. See the `Error` schema.
+        * **Compatibility** — clients should ignore unknown fields. Field removals,
+          type changes, or semantic changes require a documentation version update
+          and deprecation note.
 
         See [`/developers/apis`](https://docs.justlend.org/developers/apis) for the
         human‑readable version with tables, worked examples, and the jToken


### PR DESCRIPTION
## Summary
- Add an API quick start with a copyable read-only request and expected response.
- Document API versioning and compatibility expectations.
- Add OpenAPI metadata for schema version, compatibility policy, terms, contact, and license.

## Validation
- `git diff --check`
- `mkdocs build --strict` not run locally because `mkdocs` is not installed in the current Python environment.