### PR TITLE
Make AI docs internally consistent and self-anchored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ For the JustLend protocol itself, see governance proposals on [forum.justlend.or
 
 ## [Unreleased]
 
-### Added
+### Added — 2026-05-21 AI-data-consistency pass
+
+- **`/llms-full.txt` snapshot metadata header** (`§0`): `last_generated`, `docs_commit`, `contracts_json_source`, `mcp_server_version` so consumers can detect staleness without diffing the body.
+- **Homepage freshness admonition** in `getting_started/overview.md` covering protocol name, network (TRON Mainnet), market count (17 active + 6 legacy = 23), and pointers to the rendered footer date, `CHANGELOG.md`, and `/llms-full.txt`.
+- **Self-contained "About this page" admonitions** at the top of `developers/contracts_overview.md` and `getting_started/concepts/liquidations.md` (P1 #4 fix from the v4 audit) so that RAG chunks retrieved in isolation still carry protocol + network + units context.
+- **Structured contract overview table** in `developers/contracts_overview.md` (P1 #3) with one row per contract: address, upgradeable?, proxy mode, key functions, ABI link, doc link. Replaces the previous prose-only "navigation shell".
+- **`<link rel="llms" href="/llms.txt">` discoverability hint** in `docs/overrides/base.html` `<head>` (P1 #5) plus `Sitemap`/`Allow: /llms.txt`-class entries already in `robots.txt`.
+
+### Fixed — 2026-05-21 AI-data-consistency pass
+
+- **Cross-page jToken count contradiction (P0 #1).** `ai_support/justlend_skills.md` previously titled its 9-row table "Supported Markets", which RAG chunks misread as the protocol's full market list, contradicting `llms-full.txt` (17 active + 6 legacy = 23). Renamed to "Featured Markets (CLI Quick Reference)" and reframed: the table is now explicitly a CLI shortcut subset, with the authoritative source-of-truth ordering (live API → `contracts.json` → `apis.md` §2) stated above it. `llms-full.txt §5.2` similarly hardened to cite the same single source of truth in-chunk.
+
+### Added — prior to 2026-05-21
 - `CHANGELOG.md` (this file).
 - `mkdocs-git-revision-date-localized-plugin`: every page now shows last-updated date in the footer, sourced from git commit metadata.
 - `AI / LLMs` navigation page listing `/llms.txt`, `/llms-full.txt`, OpenAPI, `contracts.json`, and JSON ABI endpoints for agent users.

--- a/docs/ai_support/justlend_skills.md
+++ b/docs/ai_support/justlend_skills.md
@@ -34,7 +34,16 @@ The project includes 4 structured skill modules in the `/skills` directory that 
 
 The lending skill works with the built-in 9 query tools. The other three skills provide instructional guidance and require the [full MCP server](mcp_server.md) for write operations.
 
-## Supported Markets
+## Featured Markets (CLI Quick Reference)
+
+!!! warning "Not an exhaustive market list"
+    The table below lists the **9 markets the bundled CLI examples target by symbol shortcut**. It is **not** the protocol's full market roster. The JustLend DAO protocol currently exposes **17 active + 6 legacy = 23 markets total** (see the single source of truth below). All 23 are queryable through the Skills MCP server via `get_supported_markets` / `get_all_markets` — the CLI shortcuts are just a convenience subset for human terminal use.
+
+**Single source of truth for the live market list (in order of preference):**
+
+1. **Live API** — `GET https://openapi.just.network/lend/jtoken` returns the authoritative jToken list with addresses, APYs, and TVL.
+2. **Machine-readable address book** — [`/developers/contracts.json`](../developers/contracts.json) (regenerated from the MCP server's `chains.ts`).
+3. **Rendered table** — [APIs §2 — jToken Address Reference](../developers/apis.md#2-jtoken-address-reference) (all 23 markets, legacy rows tagged).
 
 | jToken | Underlying | Description |
 |--------|-----------|-------------|
@@ -48,11 +57,7 @@ The lending skill works with the built-in 9 query tools. The other three skills 
 | jWIN   | WIN       | WINkLink |
 | jHTX   | HTX       | HTX token |
 
-!!! note "Authoritative current market list"
-    The full live list (17 active + 6 legacy) is in [APIs §2 — jToken Address Reference](../developers/apis.md#2-jtoken-address-reference). Markets currently **closed** to new supply/borrow: `jUSDCOLD`, `jUSDDOLD`, `jUSDJ`, `jWBTT`, `jSUNOLD`, `jBUSDOLD`. The on-chain contracts remain queryable so existing positions can be unwound — do not direct new deposits to them.
-
-!!! tip
-    The full MCP server supports 24+ markets including jsTRX, jwstUSDT, jWBTC, and more.
+Markets currently **closed** to new supply/borrow (legacy, queryable but do not direct new deposits to them): `jUSDCOLD`, `jUSDDOLD`, `jUSDJ`, `jWBTT`, `jSUNOLD`, `jBUSDOLD`.
 
 ## Prerequisites
 

--- a/docs/developers/contracts_overview.md
+++ b/docs/developers/contracts_overview.md
@@ -1,19 +1,62 @@
 # Contracts Overview
 
+!!! info "About this page"
+    **Protocol:** JustLend DAO · **Network:** TRON Mainnet (Base58 addresses; see [`/developers/contracts.json`](contracts.json) for Mainnet + Nile addresses in Base58, EVM `0x` hex, and TRON-internal `41` hex) · **Architecture:** Compound V2 fork · **Markets:** 17 active + 6 legacy = 23 jToken markets (authoritative list: [APIs §2](apis.md#2-jtoken-address-reference)) · **Upgrade pattern:** every contract listed below is either `Delegator → Delegate` (proxy + implementation, **upgradeable** by Governance) or **immutable**, explicitly tagged in the table. The page first gives a one-screen machine-readable summary table; deeper per-component prose follows.
+
+## Architecture summary
+
 JustLend DAO Protocol contracts are divided in these repositories:
 
 * **Supply and Borrow Market:** contains core contracts for JustLend DAO, including logic for supply and borrow market (SBM), interest rate model, governance, price oracle and comptroller.
-  * **SBM:** enables supplying of crypto assets as collateral in order to borrow the base asset. Accounts can also earn interest by supplying the base asset to the protocol.
-  * **Interest Rate Model:** users with a positive balance of the base asset earn interest, denominated in the base asset, based on a supply rate model.
-  * **Price-Oracle:** contains the price oracle contracts we support, along with the logic validation for prices returned by these oracles.
-  * **Governance:** contracts used for proposing, voting and executing proposals.
-  * **Comptroller:** the risk management layer of the protocol. It determines how much collateral a user is required to maintain, and whether user can be liquidated.
+    * **SBM:** enables supplying of crypto assets as collateral in order to borrow the base asset. Accounts can also earn interest by supplying the base asset to the protocol.
+    * **Interest Rate Model:** users with a positive balance of the base asset earn interest, denominated in the base asset, based on a supply rate model.
+    * **Price-Oracle:** contains the price oracle contracts we support, along with the logic validation for prices returned by these oracles.
+    * **Governance:** contracts used for proposing, voting and executing proposals.
+    * **Comptroller:** the risk management layer of the protocol. It determines how much collateral a user is required to maintain, and whether user can be liquidated.
 * **Staked TRX:** the contracts utilized for staking TRX to earn high rewards.
 * **Energy Rental:** contracts enable users to rent energy anytime with a low price.
 
+## Contract summary table (machine-readable)
+
+Single row per contract. Use this when integrating; treat the prose sections below as commentary.
+
+| Component | Contract | Mainnet address (Base58) | Upgradeable? | Proxy mode | Key functions | ABI | Doc |
+|-----------|----------|--------------------------|--------------|------------|---------------|-----|-----|
+| Comptroller | `Unitroller` (entrypoint) | [`TGjYzgCyPobsNS9n6WcbdLVR9dH7mWqFx7`](https://tronscan.org/#/contract/TGjYzgCyPobsNS9n6WcbdLVR9dH7mWqFx7) | **Yes** (impl behind proxy) | Compound `Unitroller` (`_setPendingImplementation` + `_acceptImplementation`) | `enterMarkets`, `exitMarket`, `getAccountLiquidity`, `markets`, `closeFactorMantissa`, `liquidationIncentiveMantissa` | [`comptroller.json`](abis/comptroller.json) | [Comptroller](supply_and_borrow_market/comptroller.md) |
+| Comptroller | `Comptroller` (implementation) | [`TB23wYojvAsSx6gR8ebHiBqwSeABiBMPAr`](https://tronscan.org/#/contract/TB23wYojvAsSx6gR8ebHiBqwSeABiBMPAr) | Replaced via `Unitroller` | Implementation only | — (delegated through `Unitroller`) | [`comptroller.json`](abis/comptroller.json) | [Comptroller](supply_and_borrow_market/comptroller.md) |
+| SBM (TRX market) | `CErc20Delegator` (jTRX) | [`TE2RzoSV3wFK99w6J9UnnZ4vLfXYoxvRwP`](https://tronscan.org/#/contract/TE2RzoSV3wFK99w6J9UnnZ4vLfXYoxvRwP) | **Yes** (impl behind delegator) | Compound `CErc20Delegator` (`_setImplementation`) | `mint()` (payable, TRX), `borrow`, `repayBorrow` (payable), `redeem`, `redeemUnderlying`, `liquidateBorrow` (payable) | [`jtoken.json`](abis/jtoken.json) (plus [`jtrx-mint.json`](abis/jtrx-mint.json), [`jtrx-repay.json`](abis/jtrx-repay.json) for TRX-specific payable variants) | [SBM](supply_and_borrow_market/sbm.md) |
+| SBM (TRC20 markets) | `CErc20Delegator` (per market, 22 instances) | See [`apis.md §2`](apis.md#2-jtoken-address-reference) | **Yes** per market | Compound `CErc20Delegator` (`_setImplementation`) | `mint(uint)`, `borrow`, `repayBorrow(uint)`, `redeem`, `redeemUnderlying`, `liquidateBorrow(address, uint, address)` | [`jtoken.json`](abis/jtoken.json) | [SBM](supply_and_borrow_market/sbm.md), [Deployed Contracts](deployed_contracts.md) |
+| Interest Rate Model | `WhitePaperInterestRateModel` (linear) | Per market — see [Deployed Contracts](deployed_contracts.md) | **No** (immutable per deployment; new model contract per parameter change) | None | `getBorrowRate(cash, borrows, reserves)`, `getSupplyRate(cash, borrows, reserves, reserveFactorMantissa)` | [`interest-rate-model.json`](abis/interest-rate-model.json) | [Interest Rate Model](supply_and_borrow_market/interest_rate_model.md) |
+| Interest Rate Model | `JumpRateModelV2` (kinked) | Per market — see [Deployed Contracts](deployed_contracts.md) | **No** (immutable per deployment; new model contract per parameter change) | None | `getBorrowRate`, `getSupplyRate`, `multiplierPerBlock`, `jumpMultiplierPerBlock`, `kink`, `baseRatePerBlock` | [`interest-rate-model.json`](abis/interest-rate-model.json) | [Interest Rate Model](supply_and_borrow_market/interest_rate_model.md) |
+| Price Oracle | `PriceOracleProxy` (entrypoint) | [`TCKp2AzuhzV4B4Ahx1ej4mvQgHZ1kH7F7k`](https://tronscan.org/#/contract/TCKp2AzuhzV4B4Ahx1ej4mvQgHZ1kH7F7k) | **Yes** (impl behind proxy) | Address-only proxy (governance updates implementation pointer) | `getUnderlyingPrice(cToken)` | [`price-oracle.json`](abis/price-oracle.json) | [Price Oracle](supply_and_borrow_market/price_oracle.md) |
+| Price Oracle | `SimplePriceOracle` (implementation) | [`TMiNCmvD3zdsv6mk7niBU6NPBzVNjYMQTV`](https://tronscan.org/#/contract/TMiNCmvD3zdsv6mk7niBU6NPBzVNjYMQTV) | Replaced via proxy | Implementation only | `getPrice`, `assetPrices`, `setPrice` (poster-only) | [`price-oracle.json`](abis/price-oracle.json) | [Price Oracle](supply_and_borrow_market/price_oracle.md) |
+| Governance | `GovernorBravoDelegator` (entrypoint) | [`TEqiF5JbhDPD77yjEfnEMncGRZNDt2uogD`](https://tronscan.org/#/contract/TEqiF5JbhDPD77yjEfnEMncGRZNDt2uogD) | **Yes** (impl behind delegator) | Compound `GovernorBravoDelegator` (`_setImplementation`) | `propose`, `queue`, `execute`, `cancel`, `castVote`, `castVoteWithReason`, `state`, `deposit` | [`governor-alpha.json`](abis/governor-alpha.json) (Governor ABI; the WJST escrow is `wjst.json`) | [Governance](supply_and_borrow_market/governance.md) |
+| Governance | `GovernorBravoDelegate` (implementation) | [`TCiQTkxhzwSeXhRsNdHCvrxHRAvpjQn5Dt`](https://tronscan.org/#/contract/TCiQTkxhzwSeXhRsNdHCvrxHRAvpjQn5Dt) | Replaced via delegator | Implementation only | — (delegated) | [`governor-alpha.json`](abis/governor-alpha.json) | [Governance](supply_and_borrow_market/governance.md) |
+| Governance | `Timelock` (executor) | [`TRWNvb15NmfNKNLhQpxefFz7cNjrYjEw7x`](https://tronscan.org/#/contract/TRWNvb15NmfNKNLhQpxefFz7cNjrYjEw7x) | **No** (constructor-fixed admin and delay) | None | `queueTransaction`, `executeTransaction`, `cancelTransaction` | — | [Governance](supply_and_borrow_market/governance.md) |
+| Governance | `JST` (TRC20 governance token) | [`TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9`](https://tronscan.org/#/contract/TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9) | **No** (standard TRC20) | None | `transfer`, `approve`, `balanceOf` | [`trc20.json`](abis/trc20.json) | [Tokenomics](../governance/tokenomics.md) |
+| Governance | `WJST` (voting-power escrow) | See [Deployed Contracts](deployed_contracts.md) | **No** | None | `deposit`, `withdraw`, vote-power tracking | [`wjst.json`](abis/wjst.json) | [Governance](supply_and_borrow_market/governance.md) |
+| Staked TRX | `sTRX` (liquid-staking contract) | [`TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5`](https://tronscan.org/#/contract/TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5) | **No** (constructor-fixed; new contract on protocol upgrade) | None | `deposit()` (payable), `withdraw`, `withdrawExact`, `claim`, `claimAll`, `exchangeRate`, `balanceInTrx` | [`strx.json`](abis/strx.json) | [Staked TRX](staked_trx.md) |
+| Energy Rental | `EnergyRental` market contract | [`TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd`](https://tronscan.org/#/contract/TU2MJ5Veik1LRAgjeSzEdvmDYx7mefJZvd) | **No** | None | `rentResource` (payable), `returnResource`, `returnResourceByReceiver`, `liquidate`, `getRentInfo`, `_rentalRate` | [`energy-market.json`](abis/energy-market.json), rate model in [`energy-rate-model.json`](abis/energy-rate-model.json) | [Energy Rental](energy_rental.md) |
+
+**Inter-contract call flow (most common write path — supply + borrow):**
+
+```
+User EOA
+  └─► CErc20Delegator (jToken)
+        ├─ delegatecall ► CErc20Delegate (mint/borrow logic)
+        ├─ staticcall   ► PriceOracleProxy.getUnderlyingPrice()
+        ├─ call         ► InterestRateModel.getBorrowRate() / getSupplyRate()
+        └─ call         ► Unitroller (Comptroller proxy)
+                            └─ delegatecall ► Comptroller.mintAllowed / borrowAllowed
+```
+
+`enterMarkets` is a precondition for any supplied asset to count as collateral — it is called directly on the `Unitroller` entrypoint, not on the jToken.
+
+**Version evolution (`JumpRateModelV2`):** each market's rate model is its own deployed contract instance (immutable). Updating parameters (kink, multipliers, baseRate) means deploying a fresh `JumpRateModelV2` contract and calling `_setInterestRateModel` on the jToken via Governance. Past instances remain on chain but unused.
 
 ## **Core Contracts**
-There are 5 categories of core repository contracts:
+
+There are 5 categories of core repository contracts (the prose below mirrors the summary table — refer to the table for addresses, function signatures, and ABI links):
 
 * JTokens Contract
 * Interest Rate Model Contract
@@ -34,6 +77,7 @@ There are 5 categories of core repository contracts:
 
 ### Governance Contract
 `GovernorBravo:` The main JustLend Governance Contract. Users interact with it to:
+
 - Submit new proposal
 - Vote on a proposal
 - Cancel a proposal
@@ -50,4 +94,3 @@ There are 5 categories of core repository contracts:
 
 ## **Energy Rental**
 `Energy Rental:` contracts enable users to rent energy anytime with a low price.
-

--- a/docs/getting_started/concepts/liquidations.md
+++ b/docs/getting_started/concepts/liquidations.md
@@ -1,3 +1,6 @@
+!!! info "About this page"
+    **Protocol:** JustLend DAO (Compound V2 fork on TRON) · **Network:** TRON Mainnet · **Page scope:** how liquidation works for **SBM (Supply & Borrow Market)** positions on JustLend — risk-value formula, thresholds, on-chain mechanics, and the manual liquidation workflow. · **Unit conventions used here:** `Collateral Factor` ∈ [0, 1] (decimal, e.g. `0.80` = 80%); `Risk Value` is a percentage scalar (`100` means at the liquidation threshold, **not** `1.0`); USD amounts are de-scaled human numbers. · **Related contracts:** `Comptroller` (sets `closeFactorMantissa`, `liquidationIncentiveMantissa`, and per-market `collateralFactorMantissa`; see [Comptroller](../../developers/supply_and_borrow_market/comptroller.md)) and `CErc20Delegator` jTokens (expose `liquidateBorrow`; see [SBM](../../developers/supply_and_borrow_market/sbm.md)). · **Key terms defined inline below:** Risk Value, Borrow Limit, Total Borrow, Collateral Factor, Observation Threshold, Liquidation Threshold, Liquidation Reward.
+
 Liquidation is determined by **Risk Value**, which is a critical metric within the JustLend DAO Protocol that measures the safety of a borrow position. It is calculated as:
 
 $$

--- a/docs/getting_started/overview.md
+++ b/docs/getting_started/overview.md
@@ -1,3 +1,6 @@
+!!! info "Documentation freshness"
+    **Protocol:** JustLend DAO · **Network:** TRON Mainnet · **Markets:** 17 active + 6 legacy = 23 jToken markets ([authoritative list](../developers/apis.md#2-jtoken-address-reference)). Per-page `last-updated` is rendered in the footer (sourced from git commit history). For changelog see [CHANGELOG.md](https://github.com/justlend/justlend-docs/blob/main/CHANGELOG.md); for the machine-readable snapshot see [`/llms-full.txt`](../llms-full.txt) (header includes `last_generated` and `docs_commit`).
+
 JustLend DAO is a cutting-edge money market protocol powered by TRON, designed to create fund pools with interest rates determined by an algorithm based on the supply and demand of TRON assets. The protocol involves two main roles: suppliers and borrowers, who engage directly with the platform to earn or pay floating interest rates.
 
 Each money market on JustLend DAO represents a specific TRON asset, including TRX, TRC20 stablecoins like USDT, and other TRC20-based tokens. The platform features an open and transparent ledger that records all transactions and historical interest rates, ensuring transparency and trust among users.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,6 +2,17 @@
 
 > A condensed, single-document snapshot of the JustLend DAO documentation, intended for LLMs that prefer one-shot ingestion over per-page crawling. Authoritative source is the live site at <https://docs.justlend.org>; the OpenAPI spec at <https://docs.justlend.org/developers/apis/justlend_apis.yaml> is the machine-readable contract.
 
+## 0. Snapshot metadata
+
+| Field | Value |
+|-------|-------|
+| `last_generated` | **2026-05-21** (ISO 8601, UTC date) |
+| `docs_commit` | [`718ae87`](https://github.com/justlend/justlend-docs/commit/718ae87) (latest commit on `main` when this snapshot was generated) |
+| `contracts_json_source` | [`/developers/contracts.json`](https://docs.justlend.org/developers/contracts.json) — see its `_meta.last_generated` for the address-data snapshot date |
+| `mcp_server_version` | `@justlend/mcp-server-justlend` **v1.0.7** (sync date 2026-05-20) |
+| `changelog` | [`CHANGELOG.md`](https://github.com/justlend/justlend-docs/blob/main/CHANGELOG.md) |
+| `regenerate` | This file is updated each time the docs change materially. If you fetched it more than ~30 days ago, refresh it before answering address / market / version questions. |
+
 This document covers: protocol overview, core concepts (supply / borrow / withdraw / repay / liquidation / risks / sTRX / energy rental), governance, developer contract reference, deployed addresses (TRON mainnet + Nile), the HTTP API surface, and the AI integration story (Skills + MCP). For exhaustive function signatures, field-by-field response schemas, JSON ABIs, and machine-readable address formats, see the individual reference pages and the OpenAPI YAML.
 
 ---
@@ -300,7 +311,9 @@ The rendered tables below summarize **TRON Mainnet** Base58 addresses. For machi
 
 ### 5.2 jToken delegators (the addresses users interact with)
 
-The protocol currently exposes **17 active** + **6 legacy** = 23 markets. Rows tagged `(legacy)` are **closed to new supply and borrow** — existing positions can still be unwound but do not direct new deposits to them. Always cross-check with `apis.md §2` for the latest status.
+**Protocol-wide market count: 17 active + 6 legacy = 23 jToken markets total** (TRON Mainnet, as of the `last_generated` date in §0 above). Rows tagged `(legacy)` are **closed to new supply and borrow** — existing positions can still be unwound but do not direct new deposits to them.
+
+Single source of truth (in order of preference): (1) live `GET https://openapi.just.network/lend/jtoken`, (2) `/developers/contracts.json`, (3) `apis.md §2`. Any other page that quotes a smaller count (e.g. the 9-market "featured" table in `ai_support/justlend_skills.md`) is showing a CLI-convenience subset, not the full protocol roster.
 
 Note: the dApp UI has renamed two markets — `jETH` is displayed as "ETH" (formerly "ETHOLD"), and `jETHB` is displayed as "ETHB" (formerly "ETH"). On-chain addresses are unchanged.
 

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -80,6 +80,15 @@
         <meta {% for key, value in tag.items() %} {{ key }}="{{value}}" {% endfor %}>
       {% endfor %}
     {% endif %}
+    {# AI / LLM discoverability hints — non-standard rel values per llmstxt.org. #}
+    {# Crawlers that don't recognize them ignore them; the ones that do (and    #}
+    {# tools that look for them, e.g. agent indexers) can locate the AI-only   #}
+    {# entry files without guessing paths.                                     #}
+    <link rel="llms" href="{{ '/llms.txt' | url }}" type="text/plain">
+    <link rel="llms-full" href="{{ '/llms-full.txt' | url }}" type="text/plain">
+    <link rel="alternate" type="text/plain" title="llms.txt — site index for LLMs" href="{{ '/llms.txt' | url }}">
+    <link rel="alternate" type="text/plain" title="llms-full.txt — full-text snapshot for LLMs" href="{{ '/llms-full.txt' | url }}">
+    <meta name="ai-content-declaration" content="llms.txt,llms-full.txt">
     {% block extrahead %}{% endblock %}
   </head>
   {% set direction = config.theme.direction or lang.t("direction") %}

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -70,7 +70,14 @@ Allow: /
 # Authoritative entry points for AI agents
 Sitemap: https://docs.justlend.org/sitemap.xml
 
-# AI-friendly indexes (RFC-style hints; non-standard but increasingly recognized)
-# llms.txt — site navigation for LLMs
-# llms-full.txt — condensed full-text snapshot
-# See: https://llmstxt.org/
+# AI-friendly indexes (non-standard but increasingly recognized — see https://llmstxt.org/).
+# These appear here both as explicit `Allow:` rules (so crawlers know they're fair game)
+# and as named entry points for tools that scan robots.txt for AI metadata.
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /developers/contracts.json
+Allow: /developers/abis/
+
+# Named entry points (non-standard directives — recognized by some AI indexers).
+LLM-Index: https://docs.justlend.org/llms.txt
+LLM-Full-Index: https://docs.justlend.org/llms-full.txt


### PR DESCRIPTION
## Summary

Closes the P0 / P1 items from the v4 AI-readability audit (see screenshot). Fixes the cross-page contradiction RAG systems hit when chunking by section, adds explicit freshness signals so agents can detect stale snapshots, and makes page-level chunks self-contained.

### P0 fixes

- **Cross-page jToken count contradiction (P0 #1).** `ai_support/justlend_skills.md` previously titled its 9-row table "Supported Markets" — a RAG chunk retrieved in isolation read this as the protocol's full market list, directly contradicting `llms-full.txt`'s "17 active + 6 legacy = 23 markets". Renamed to **"Featured Markets (CLI Quick Reference)"** and reframed with a single source-of-truth ordering (live API → `contracts.json` → `apis.md §2`) stated above the table. `llms-full.txt §5.2` hardened to cite the same SOT in-chunk and explicitly note that smaller per-page counts are CLI-convenience subsets, not the full roster.
- **Freshness signals (P0 #2).** New `§0` metadata header in `llms-full.txt` with `last_generated`, `docs_commit`, `contracts_json_source`, `mcp_server_version` so consumers can detect staleness without diffing the body. New "Documentation freshness" admonition at the top of `getting_started/overview.md` (the homepage redirect target, whose footer date was stuck at 2025-08-01) pointing to the rendered footer date, CHANGELOG.md, and `/llms-full.txt`.

### P1 fixes

- **Structured contract overview table (P1 #3).** `developers/contracts_overview.md` now has one row per contract with address (Tronscan-linked), `Upgradeable?` (Yes/No with proxy mode), key functions, ABI link, and doc link. Covers Comptroller (Unitroller + impl), SBM jTRX + per-market `CErc20Delegator`, both interest-rate model variants, PriceOracle (proxy + impl), Governor (delegator + impl) + Timelock + JST + WJST, sTRX, and Energy Rental. Includes a call-flow diagram for the most common supply+borrow write path and a note on `JumpRateModelV2` version evolution (new contract per parameter change). Replaces the previous prose-only "navigation shell".
- **Self-contained chunks (P1 #4).** "About this page" admonitions on the two pages the audit flagged as heavily cross-referential (`contracts_overview.md` and `liquidations.md`). Each names protocol, network, page scope, unit conventions (e.g. `Collateral Factor ∈ [0, 1]`; `Risk Value` is a percentage scalar where 100 = liquidation threshold), and related contracts, so a RAG chunk retrieved in isolation still carries enough context.
- **llms.txt discoverability (P1 #5).** `base.html` now emits `<link rel="llms" href="/llms.txt" type="text/plain">`, `<link rel="llms-full" …>`, two `rel="alternate"` duplicates for crawlers that don't recognize the bespoke rel values, and a `<meta name="ai-content-declaration">`. `robots.txt` promoted the existing comment into explicit `Allow:` rules for `/llms.txt`, `/llms-full.txt`, `/developers/contracts.json`, `/developers/abis/`, plus non-standard `LLM-Index:` / `LLM-Full-Index:` directives.

CHANGELOG.md updated with a new "2026-05-21 AI-data-consistency pass" entry under `[Unreleased]`.

## Test plan

- [x] `mkdocs build --strict` passes (no new warnings introduced by these changes).
- [x] `<link rel="llms">` and `<meta name="ai-content-declaration">` appear in the built `index.html` and `getting_started/overview/index.html`.
- [x] Rendered "Featured Markets (CLI Quick Reference)" heading replaces the old "Supported Markets" heading on `ai_support/justlend_skills/`.
- [x] Rendered "About this page" admonition appears on both `developers/contracts_overview/` and `getting_started/concepts/liquidations/`.
- [ ] Spot-check that the per-page footer `last-updated` date on the homepage now reflects the commit landed by this PR (will be true after merge to main, since the plugin reads `git log`).