### PR TITLE
docs: sync MCP server to v1.0.8 + correct API error contract to match live behavior

### DIFF
--- a/docs/ai_support/mcp_server.md
+++ b/docs/ai_support/mcp_server.md
@@ -1,6 +1,6 @@
 ---
 title: JustLend MCP Server (full, read + write)
-description: "@justlend/mcp-server-justlend v1.0.7 — 59 MCP tools for supply, borrow, repay, sTRX staking, energy rental, governance voting, mining rewards, transfers, plus general TRON utilities. Dual-mode signing (browser TronLink or encrypted agent-wallet)."
+description: "@justlend/mcp-server-justlend v1.0.8 — 59 MCP tools for supply, borrow, repay, sTRX staking, energy rental, governance voting, mining rewards, transfers, plus general TRON utilities. Dual-mode signing (browser TronLink or encrypted agent-wallet)."
 ---
 
 # MCP Server
@@ -27,10 +27,10 @@ The JustLend MCP Server (`@justlend/mcp-server-justlend`) is a [Model Context Pr
 Beyond JustLend-specific operations, the server also exposes a full set of **general-purpose TRON chain utilities** — balance queries, block/transaction data, token metadata, TRX transfers, smart contract reads/writes, staking (Stake 2.0), multicall, and more.
 
 !!! note
-    Current version (**v1.0.7**) supports **JustLend V1** protocol. All contract addresses, ABIs, calculation functions, and lending operations are for V1.
+    Current version (**v1.0.8**) supports **JustLend V1** protocol. All contract addresses, ABIs, calculation functions, and lending operations are for V1.
 
-!!! tip "v1.0.7 Update"
-    This release keeps the **59-tool** surface and focuses on dependency/runtime freshness plus precision-safe staking. It uses `@modelcontextprotocol/sdk` `1.29.0`, `tronweb` `6.2.2`, `@bankofai/agent-wallet` `2.3.0`, and `tronlink-signer` `0.1.1`; sTRX staking paths use string/BigInt parsing for TRX Sun conversion and 18-decimal sTRX balances/exchange-rate display. The v1.0.6 safety work remains in place: TRC20 allowance checks before supply/repay, explicit approval amounts, typed broadcast handling, governance failed-proposal filtering, and Nile mining fallback.
+!!! tip "v1.0.8 Update"
+    This release keeps the **59-tool** surface and is a **security-hardening release** addressing the 2026-06-03 full-audit findings, plus dependency advisory cleanup. Transitive `npm audit` advisories are cleared by pinning `qs` `6.15.2` and `ws` `8.20.1` (alongside the existing `fast-uri` `3.1.2` override). Runtime deps are unchanged from v1.0.7: `@modelcontextprotocol/sdk` `1.29.0`, `tronweb` `6.2.2`, `@bankofai/agent-wallet` `2.3.0`, `tronlink-signer` `0.1.1`. A machine-readable tool catalog (`mcp-api-list.md`, generated from source) now ships in the repo for offline agent routing. All prior safety work remains in place: TRC20 allowance checks before supply/repay, explicit approval amounts (unlimited `max` is opt-in only, with a revoke hint), typed broadcast handling, `toSafeCallValueNumber` guards on every broadcast/simulation path, mainnet fail-closed on pre-flight `REVERT`, constant-time `MCP_API_KEY` comparison, governance failed-proposal filtering, and Nile mining fallback.
 
 ## Overview
 

--- a/docs/developers/apis.md
+++ b/docs/developers/apis.md
@@ -140,28 +140,33 @@ Endpoints that accept `pageNo` and `pageSize` return:
 
 - `pageNo` is 1‑based. Default = `1`.
 - `pageSize` default = `10`, **max = `1000`**.
+- Invalid or out-of-range `pageNo`/`pageSize` are often **silently ignored** (defaults applied, `200 SUCCESS`) rather than rejected — validate client-side. See [§1.6 Error responses](#16-error-responses).
 
 ### 1.6 Error responses
 
-`code` is non‑zero and a payload conforming to [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) is returned:
+> **Important for clients and AI agents:** business and validation outcomes are returned with **HTTP `200`** and the same `{ code, message, data }` envelope — **not** signalled through HTTP status codes, and **not** in RFC 7807 form. **Branch on the body `code`, not the HTTP status.** Only transport-level conditions (rate limiting, server faults) surface as non-`200` HTTP statuses.
+
+**Business / validation errors — HTTP `200`, `code` ≠ 0, `data` omitted:**
 
 ```json
-{
-  "type": "https://example.com/errors/generic-error",
-  "title": "Something went wrong here.",
-  "status": 400,
-  "detail": "Unfortunately, we can't provide further information."
-}
+{ "code": 404, "message": "interface [/lend/nonExistentXYZ] non exist" }
 ```
 
-| HTTP status | Meaning                                          |
-|-------------|--------------------------------------------------|
-| `400`       | Bad Request — missing or malformed parameters.   |
-| `401`       | Unauthorized.                                    |
-| `403`       | Forbidden.                                       |
-| `404`       | Not Found.                                       |
-| `429`       | Too Many Requests — slow down and retry with exponential backoff. |
-| `5xx`       | Server error. Safe to retry with backoff.        |
+| Signal | How to detect failure |
+|--------|------------------------|
+| Body `code` | `0` = success. Any non-zero value (e.g. `1`, `404`) is an error — read `message`; `data` is typically absent or `null`. |
+| HTTP status | `200` for virtually all business/validation outcomes, **including "not found" and invalid parameters**. Do **not** use the HTTP status to detect business errors. |
+
+**Transport-level statuses (the only non-`200` HTTP codes to expect):**
+
+| HTTP status | Meaning | Retry |
+|-------------|---------|-------|
+| `429` | Too Many Requests — throttled. | Yes — exponential backoff (see §1.7). |
+| `5xx` | Server error. | Yes — with backoff. |
+
+**Silent parameter handling (must-know):** unknown or out-of-range query parameters (e.g. `pageSize=invalid`, `pageNo=-1`) are commonly **silently ignored** — the service returns `200 SUCCESS` with default data rather than rejecting the request. Some endpoints do return a non-zero `code` (e.g. `{"code":1,"message":"illegal pageNo or pageSize"}`), but **this is not guaranteed**. The API does **not** reliably validate inputs for you: **validate parameters client-side** and never assume a malformed request will fail.
+
+> This error contract reflects the live service as of 2026-06-08. A future API revision may adopt HTTP status codes and/or a structured error body; until then, treat HTTP `200` + body `code` as authoritative and validate inputs client-side.
 
 ### 1.7 Rate limits and retry
 

--- a/docs/developers/apis/justlend_apis.yaml
+++ b/docs/developers/apis/justlend_apis.yaml
@@ -36,7 +36,7 @@ info:
         * **Mining APY** — paid on top of `supplyRate`. Effective supply APY = `supplyRate + apy`.
         * **Pagination** — `pageNo` is 1‑based, default `1`. `pageSize` default `10`, max `1000`.
         * **Rate limits** — public unauthenticated traffic may be throttled. Cache stable metadata and retry `429` / transient `5xx` with exponential backoff and jitter.
-        * **Errors** — non‑zero `code` plus an RFC 7807 body. See the `Error` schema.
+        * **Errors** — returned with **HTTP `200`** and the standard `{ code, message }` envelope (business errors set a non‑zero `code`, e.g. `404` or `1`; `data` is omitted). The API is **not** RFC 7807 and does **not** use HTTP status codes for business/validation errors — branch on the body `code`. Invalid/unknown query params may be silently ignored (`200 SUCCESS`), so validate inputs client‑side. Only `429` (throttle) and `5xx` (server fault) appear as non‑`200` HTTP statuses. See the `Error` schema.
         * **Compatibility** — clients should ignore unknown fields. Field removals,
           type changes, or semantic changes require a documentation version update
           and deprecation note.
@@ -81,8 +81,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/MarketListResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -107,8 +105,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/AccountListResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -128,8 +124,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HighRiskAccountListResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -162,8 +156,6 @@ paths:
                                 data:
                                     TKFRELGGoRgiayhwJTNNLqCNjFoLBh3Mnf:
                                         USDD: 0.09175706
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -197,8 +189,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/MiningRewardResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -227,8 +217,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/MiningDistributionsResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -247,8 +235,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/StrxSnapshotResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -272,8 +258,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/StrxStakeAccountResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -298,8 +282,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/RentAccountResponse'
-                '400':
-                    $ref: '#/components/responses/BadRequest'
                 '429':
                     $ref: '#/components/responses/TooManyRequests'
 
@@ -361,12 +343,6 @@ components:
             schema: { type: number, format: double }
 
     responses:
-        BadRequest:
-            description: Bad Request — missing or malformed parameters.
-            content:
-                application/json:
-                    schema:
-                        $ref: '#/components/schemas/Error'
         TooManyRequests:
             description: Too Many Requests — slow down and retry with exponential backoff and jitter.
             headers:
@@ -409,12 +385,15 @@ components:
 
         Error:
             type: object
-            description: RFC 7807 problem document.
+            description: >-
+                Error response. Returned with HTTP 200 and the same envelope as success — a
+                non-zero `code` plus a human-readable `message` (`data` is omitted). The API is
+                NOT RFC 7807 and does NOT use HTTP status codes for business/validation errors;
+                branch on `code`. Invalid params may be silently ignored (200 SUCCESS).
             properties:
-                type:   { type: string, example: 'https://docs.justlend.org/errors/bad-request' }
-                title:  { type: string, example: 'Bad Request' }
-                status: { type: integer, format: int32, example: 400 }
-                detail: { type: string, example: 'Parameter `addresses` is required.' }
+                code:    { type: integer, format: int32, example: 404, description: 'Non-zero error code (e.g. 404 "interface non exist", 1 "illegal pageNo or pageSize").' }
+                message: { type: string, example: 'interface [/lend/nonExistentXYZ] non exist', description: 'Human-readable error description.' }
+            required: [code, message]
 
         # ------------------------------------------------------------------
         # /lend/jtoken

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9,7 +9,7 @@
 | `last_generated` | **{{LAST_GENERATED}}** (ISO 8601, UTC date — substituted at build time) |
 | `docs_commit` | [`{{DOCS_COMMIT_SHORT}}`](https://github.com/justlend/justlend-docs/commit/{{DOCS_COMMIT}}) (the commit SHA this snapshot was built from — substituted at build time) |
 | `contracts_json_source` | [`/developers/contracts.json`](https://docs.justlend.org/developers/contracts.json) — see its `_meta.last_generated` for the address-data snapshot date |
-| `mcp_server_version` | `@justlend/mcp-server-justlend` **v1.0.7** (sync date 2026-05-20) |
+| `mcp_server_version` | `@justlend/mcp-server-justlend` **v1.0.8** (sync date 2026-06-08) |
 | `changelog` | [`CHANGELOG.md`](https://github.com/justlend/justlend-docs/blob/main/CHANGELOG.md) |
 | `regenerate` | This file is updated each time the docs change materially. If you fetched it more than ~30 days ago, refresh it before answering address / market / version questions. |
 
@@ -436,7 +436,7 @@ Built-in MCP tools (all read-only): `get_all_markets`, `get_dashboard`, `get_sup
 
 ### 7.2 Full MCP Server — `@justlend/mcp-server-justlend`
 
-Read + write MCP server, **59 tools**, version **v1.0.7**. Repo: <https://github.com/justlend/mcp-server-justlend>. Targets **JustLend V1**.
+Read + write MCP server, **59 tools**, version **v1.0.8**. Repo: <https://github.com/justlend/mcp-server-justlend>. Targets **JustLend V1**. A machine-readable tool catalog ([`mcp-api-list.md`](https://github.com/justlend/mcp-server-justlend/blob/main/mcp-api-list.md)) lists every tool's input schema and side-effect class for offline agent routing.
 
 Capability domains:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,7 +48,8 @@
 
 - [AI / LLMs](https://docs.justlend.org/ai_support/ai_llms): Human-readable directory for `llms.txt`, `llms-full.txt`, OpenAPI, contract JSON, and ABI JSON endpoints.
 - [JustLend Skills](https://docs.justlend.org/ai_support/justlend_skills) (`@justlend/justlend-skills`): Read-only skills package + lightweight MCP server (**9 query tools**). Source: <https://github.com/justlend/justlend-skills>.
-- [Full MCP Server](https://docs.justlend.org/ai_support/mcp_server) (`@justlend/mcp-server-justlend`, v1.0.7, **59 tools**): Full read/write MCP server for supply, borrow, repay, withdraw, sTRX staking, energy rental, governance voting, mining rewards, transfers, and general TRON utilities. Source: <https://github.com/justlend/mcp-server-justlend>.
+- [Full MCP Server](https://docs.justlend.org/ai_support/mcp_server) (`@justlend/mcp-server-justlend`, v1.0.8, **59 tools**): Full read/write MCP server for supply, borrow, repay, withdraw, sTRX staking, energy rental, governance voting, mining rewards, transfers, and general TRON utilities. Source: <https://github.com/justlend/mcp-server-justlend>.
+- [MCP machine-readable tool catalog](https://github.com/justlend/mcp-server-justlend/blob/main/mcp-api-list.md) (`mcp-api-list.md`): Offline-loadable list of all 59 tools with input schemas (param/type/required/default), side-effect class (read-only vs on-chain write/destructive) and HITL guidance. Generated from source, so it never drifts from the tool definitions.
 - [MCP source ABIs and network config](https://github.com/justlend/mcp-server-justlend): Upstream TypeScript definitions used to generate the docs JSON ABI and address files.
 
 ## API endpoints (read-only HTTP API)


### PR DESCRIPTION
Two AI-readiness doc fixes for the JustLend developer docs.

## 1. Sync MCP server docs to v1.0.8

`ai_support/mcp_server.md`, `llms.txt`, `llms-full.txt` still referenced `@justlend/mcp-server-justlend` **v1.0.7** while the published server is **v1.0.8** (security-hardening release).

- `mcp_server.md`: bump frontmatter + version note to v1.0.8; v1.0.8 update tip (2026-06-03 full-audit fixes, `qs`/`ws` override cleanup, runtime deps unchanged, new `mcp-api-list.md`).
- `llms.txt` / `llms-full.txt`: bump MCP version to v1.0.8; add the machine-readable tool catalog entry.

## 2. Correct the API error contract to match the live service

Live testing (2026-06-08) of `https://openapi.just.network` showed the documented error contract **contradicted reality** — the most dangerous doc state for an AI agent (it would branch on HTTP status codes and parse RFC 7807 fields that never appear):

| Probe | Doc claimed | Live actual |
|-------|-------------|-------------|
| Non-existent endpoint | non-zero `code` + RFC 7807 + HTTP 4xx | **HTTP 200**, `{"code":404,"message":"... non exist"}` (JSON, no RFC 7807) |
| Invalid pagination (`pageNo=-1`) | HTTP 400 | **HTTP 200 SUCCESS** (params silently ignored) |
| `pageSize=invalid` | rejected | **HTTP 200 SUCCESS** (silently ignored) |

Fixes (docs now match the live API):
- **`apis.md` §1.6**: rewritten — all business/validation outcomes return **HTTP 200** with the `{code,message,data}` envelope (error = non-zero `code`, `data` omitted); **not** RFC 7807, **not** HTTP status codes; only `429`/`5xx` are non-200; invalid params are silently ignored so clients must validate input. §1.5: silent-param caveat added.
- **`justlend_apis.yaml`** (source of truth): `Error` schema `type/title/status/detail` (RFC 7807) → `{code, message}`; Errors description corrected; removed the false `'400' BadRequest` responses from all 9 endpoints + the now-unused `BadRequest` component. YAML validated (9 paths intact).

> **Backend follow-up (separate, API team):** make the service honor HTTP status codes and reject invalid params. This PR only makes the docs truthful in the meantime.

Source files only; `site/` is regenerated by CI. Recommend `mkdocs build --strict` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
