### PR TITLE
fix(ai): correct llms.txt + aidocs endpoint paths to match the OpenAPI contract

### DIFF
--- a/docs/documents/aidocs/account_position.md
+++ b/docs/documents/aidocs/account_position.md
@@ -37,7 +37,7 @@ The answer should summarize:
 
 ## OpenAPI fallback
 
-Use `GET /lend/account/{address}` from `https://openapi.just.network` for read-only integrations.
+Use `GET /lend/account?address={address}` from `https://openapi.just.network` for read-only integrations.
 
 Schema: [`/developers/apis/justlend_apis.yaml`](../../developers/apis/justlend_apis.yaml)
 

--- a/docs/documents/aidocs/common_questions.md
+++ b/docs/documents/aidocs/common_questions.md
@@ -29,7 +29,7 @@ Chinese: “JustLend 有哪些市场？”、“支持哪些币种？”
 
 ### What is the APY for jUSDT / jTRX / another market?
 
-Use MCP `get_market_data` for one market or `get_all_markets` for all markets. For HTTP integration, use OpenAPI `GET /lend/jtoken` or `GET /lend/jtoken/{address}`.
+Use MCP `get_market_data` for one market or `get_all_markets` for all markets. For HTTP integration, use OpenAPI `GET /lend/jtoken` or `GET /lend/jtoken?address={jToken}`.
 
 Chinese: “USDT 存款年化多少？”、“TRX 借款 APY 多少？”
 
@@ -37,7 +37,7 @@ Chinese: “USDT 存款年化多少？”、“TRX 借款 APY 多少？”
 
 ### How do I check a JustLend account position?
 
-Use MCP `get_account_summary` with the user's TRON address and network. For HTTP integration, use `GET /lend/account/{address}`.
+Use MCP `get_account_summary` with the user's TRON address and network. For HTTP integration, use `GET /lend/account?address={address}`.
 
 Chinese: “查一下这个地址的 JustLend 仓位”、“这个地址健康因子是多少？”
 

--- a/docs/documents/aidocs/market_data.md
+++ b/docs/documents/aidocs/market_data.md
@@ -27,8 +27,8 @@ Use this page when the user asks about supported markets, APY, TVL, utilization,
 ### OpenAPI
 
 - `GET /lend/jtoken`: all jToken markets and live market data.
-- `GET /lend/jtoken/{address}`: details for a specific jToken.
-- `GET /lend/dashboard`: protocol-level totals.
+- `GET /lend/jtoken?address={jToken}`: details for a specific jToken.
+- Protocol-level totals: aggregate `GET /lend/jtoken` (no dedicated dashboard endpoint).
 
 Schema: [`/developers/apis/justlend_apis.yaml`](../../developers/apis/justlend_apis.yaml)
 
@@ -65,7 +65,7 @@ Do not hard-code APY, TVL, utilization, liquidity, price, reward APY, or paused 
 | User question | Best source |
 |---------------|-------------|
 | “JustLend supports which markets?” | MCP `get_supported_markets` |
-| “What is jUSDT supply APY?” | MCP `get_market_data` or OpenAPI `/lend/jtoken/{address}` |
+| “What is jUSDT supply APY?” | MCP `get_market_data` or OpenAPI `/lend/jtoken?address={jToken}` |
 | “Show all market TVL and utilization.” | MCP `get_all_markets` or OpenAPI `/lend/jtoken` |
 | “What is the jUSDT contract address?” | `contracts.json` or MCP `get_supported_markets` |
 | “Is jWBTT still active?” | `contracts.json` status + MCP market data |

--- a/docs/documents/aidocs/quickstart.md
+++ b/docs/documents/aidocs/quickstart.md
@@ -35,7 +35,7 @@ JustLend DAO is a decentralized lending protocol on TRON based on the Compound V
 ## Minimal decision tree
 
 1. **Question only needs public data**: use OpenAPI or read-only MCP tools.
-2. **Question needs portfolio analysis for an address**: use MCP `get_account_summary` or OpenAPI `/lend/account/{address}`.
+2. **Question needs portfolio analysis for an address**: use MCP `get_account_summary` or OpenAPI `/lend/account?address={address}`.
 3. **Question asks to execute an action**: use MCP only, read [`mcp_safety.md`](mcp_safety.md), require human confirmation, and never ask for private keys in chat.
 4. **Question asks for contract addresses**: use `contracts.json` and specify network.
 5. **Question asks for terms such as collateral factor, exchange rate, or mantissa**: use [`glossary.md`](glossary.md) and the full glossary page.

--- a/docs/documents/aidocs/source_of_truth.md
+++ b/docs/documents/aidocs/source_of_truth.md
@@ -60,7 +60,7 @@ The public HTTP API returns numbers in their on-chain form (e.g. base units, man
 |---------------|-----------|----------|
 | “What markets does JustLend support?” | MCP `get_supported_markets` or OpenAPI `/lend/jtoken` | `contracts.json` |
 | “What is the APY / TVL / utilization?” | MCP `get_market_data` / `get_all_markets` | OpenAPI `/lend/jtoken` |
-| “What is this address's health factor?” | MCP `get_account_summary` | OpenAPI `/lend/account/{address}` |
+| “What is this address's health factor?” | MCP `get_account_summary` | OpenAPI `/lend/account?address={address}` |
 | “Supply / borrow / repay / withdraw for me” | MCP guided prompt + tool | Human docs for explanation only |
 | “What contract address should I use?” | `contracts.json` | MCP `get_supported_markets` / `chains.ts` |
 | “How do I decode events?” | ABI JSON files | developer pages |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -71,11 +71,10 @@
 
 Base URL: `https://openapi.just.network`. Schema in [justlend_apis.yaml](https://docs.justlend.org/developers/apis/justlend_apis.yaml). Endpoints include:
 
-- `GET /lend/jtoken` — All jToken markets with supply/borrow APY, mining rewards, TVL.
-- `GET /lend/jtoken/{address}` — Single jToken details.
-- `GET /lend/account/{address}` — Account positions, health factor, rewards.
-- `GET /lend/dashboard` — Protocol-level totals (TVL, supply, borrow, users).
-- `GET /lend/mining` — Mining reward configuration and status.
+- `GET /lend/jtoken` — All jToken markets with supply/borrow APY, mining rewards, TVL (aggregate for protocol-level totals).
+- `GET /lend/jtoken?address={jToken}` — Single jToken market details.
+- `GET /lend/account?address={address}` — Account SBM positions, health factor, rewards (paginated).
+- `GET /mining/reward?address={jToken}` · `GET /mining/apy` · `GET /mining/distributions?addr={address}` — Mining reward config / per-market APY / distribution snapshots.
 
 Refer to the OpenAPI spec for the full endpoint list, request parameters, response schemas, units, and error responses.
 


### PR DESCRIPTION
## Problem
The `llms.txt` "API endpoints" shortcut list and several `aidocs` pages listed endpoint forms that **404 on the live gateway** (`https://openapi.just.network`), contradicting the authoritative `justlend_apis.yaml` + `llms-full.txt`. An AI agent following the shortcut list would fire failing requests.

## Verified live against `https://openapi.just.network`
| listed (wrong) | result | correct |
|---|---|---|
| `GET /lend/jtoken/{address}` | `code:404 interface non exist` | `GET /lend/jtoken?address={jToken}` → 200 |
| `GET /lend/account/{address}` | 404 | `GET /lend/account?address={address}` → 200 |
| `GET /lend/dashboard` | 404 | removed — no such endpoint; aggregate `GET /lend/jtoken` |
| `GET /lend/mining` | 404 | `GET /mining/reward?address=` · `GET /mining/apy` · `GET /mining/distributions?addr=` |

## Fix
Aligned the human-readable shortcut lists to the OpenAPI contract across `llms.txt` + `aidocs/{market_data,account_position,common_questions,quickstart,source_of_truth}`. `llms-full.txt` and `justlend_apis.yaml` were already correct — this removes the self-contradiction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)