### PR TITLE
docs: add guide for resolving contract addresses

### DIFF
--- a/docs/developers/contracts_overview.md
+++ b/docs/developers/contracts_overview.md
@@ -17,7 +17,7 @@ description: Architecture summary of every JustLend DAO contract on TRON — SBM
 
 JustLend DAO Protocol contracts are divided in these repositories:
 
-* **Supply and Borrow Market:** contains core contracts for JustLend DAO, including logic for supply and borrow market (SBM), supply and borrow market V2 (SBM V2)，interest rate model, governance, price oracle and comptroller.
+* **Supply and Borrow Market:** contains core contracts for JustLend DAO, including logic for supply and borrow market (SBM), supply and borrow market V2 (SBM V2), interest rate model, governance, price oracle and comptroller.
   * **SBM:** enables supplying of crypto assets as collateral in order to borrow the base asset. Accounts can also earn interest by supplying the base asset to the protocol.
   * **SBM V2:** an isolated-collateral lending protocol with a dual-layer structure of Vaults and Markets, along with an Adaptive Curve Interest Rate Model (IRM) for dynamic rate adjustment.
   * **Interest Rate Model:** users with a positive balance of the base asset earn interest, denominated in the base asset, based on a supply rate model.

--- a/docs/developers/resolving_contract_addresses.md
+++ b/docs/developers/resolving_contract_addresses.md
@@ -1,0 +1,63 @@
+---
+title: Resolving Contract Addresses
+description: How to look up JustLend jToken, underlying, and Moolah market identifiers from contracts.json and the public REST API on TRON mainnet and Nile testnet.
+---
+
+# Resolving Contract Addresses
+
+!!! info "About this page"
+    **Protocol:** JustLend DAO · **Network:** TRON (Mainnet + Nile) · **Scope:** map human-facing symbols (`jUSDT`, `USDT`, Moolah vault names) to on-chain Base58 / hex addresses without hard-coding. Use this when integrating lending flows, MCP tools, or indexers that need stable identifiers.
+
+## Machine-readable registry
+
+[`contracts.json`](contracts.json) is the canonical address book. Each entry includes:
+
+| Field | Use |
+|-------|-----|
+| `symbol` | Human label (`jUSDT`, `USDT`, `Moolah TRX Vault`) |
+| `type` | `jToken`, `underlying`, `comptroller`, `moolah-vault`, `moolah-market`, … |
+| `network` | `mainnet` or `nile` |
+| `address.base58` | TRON Base58 (`T…`) for TronWeb `.send()` / `.call()` |
+| `address.evm` | `0x…` hex for ABI tooling |
+| `address.tronHex` | `41…` internal hex |
+| `status` | `active` or `legacy` (filter to `active` for new integrations) |
+
+### Example: jToken from underlying symbol
+
+```javascript
+import contracts from './contracts.json' assert { type: 'json' };
+
+function jTokenForUnderlying(underlyingSymbol, network = 'mainnet') {
+  const underlying = contracts.find(
+    (c) => c.type === 'underlying' && c.symbol === underlyingSymbol && c.network === network
+  );
+  if (!underlying) throw new Error(`Unknown underlying: ${underlyingSymbol}`);
+
+  const jtoken = contracts.find(
+    (c) =>
+      c.type === 'jToken' &&
+      c.network === network &&
+      c.underlying === underlying.symbol &&
+      c.status === 'active'
+  );
+  if (!jtoken) throw new Error(`No active jToken for ${underlyingSymbol}`);
+  return jtoken.address.base58;
+}
+
+// jUSDT on mainnet
+console.log(jTokenForUnderlying('USDT'));
+```
+
+## REST API fallback
+
+When you need live APY/TVL alongside addresses, call the public market list (see [APIs §1](apis.md#1-market-list)) and join on `jtokenAddress` or `underlyingAddress`. The MCP server uses contract queries first with this API as fallback for reliability.
+
+## Moolah V2 identifiers
+
+Isolated markets are keyed by `MarketParams`: `(loanToken, collateralToken, oracle, irm, lltv)`. Vault entries in `contracts.json` list the ERC-4626 share token; market tuples are documented in [SBM V2](supply_and_borrow_market/sbmV2.md). Resolve loan/collateral addresses with the same registry before constructing calldata.
+
+## Related pages
+
+- [Contracts Overview](contracts_overview.md)
+- [Common Pitfalls](common_pitfalls.md)
+- [MCP Server](../ai_support/mcp_server.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
         - Staked TRX: developers/staked_trx.md
         - Energy Rental: developers/energy_rental.md
         - Deployed Contracts: developers/deployed_contracts.md
+        - Resolving Contract Addresses: developers/resolving_contract_addresses.md
         - APIs: developers/apis.md
         - ABI Files: developers/abis/index.md
         - Common Pitfalls: developers/common_pitfalls.md


### PR DESCRIPTION
## Problem
No open maintainer issues in justlend-docs. Integrators repeatedly hard-code jToken addresses instead of using the canonical registry.

## Approach
Add **Resolving Contract Addresses** developer guide covering `contracts.json` fields, jToken lookup by underlying symbol, REST API fallback, and Moolah V2 identifiers. Fix a punctuation typo in Contracts Overview.

## Test plan
- [x] mkdocs nav entry added
- [ ] `mkdocs build --strict` in CI

FALLBACK: no maintainer-authored issues; docs-only contribution in the JustLend org.
