### PR TITLE
docs: fix contract address resolution and sTRX copy

### DIFF
--- a/docs/developers/contracts_overview.md
+++ b/docs/developers/contracts_overview.md
@@ -17,7 +17,7 @@ description: Architecture summary of every JustLend DAO contract on TRON — SBM
 
 JustLend DAO Protocol contracts are divided in these repositories:
 
-* **Supply and Borrow Market:** contains core contracts for JustLend DAO, including logic for supply and borrow market (SBM), supply and borrow market V2 (SBM V2)，interest rate model, governance, price oracle and comptroller.
+* **Supply and Borrow Market:** contains core contracts for JustLend DAO, including logic for supply and borrow market (SBM), supply and borrow market V2 (SBM V2), interest rate model, governance, price oracle and comptroller.
   * **SBM:** enables supplying of crypto assets as collateral in order to borrow the base asset. Accounts can also earn interest by supplying the base asset to the protocol.
   * **SBM V2:** an isolated-collateral lending protocol with a dual-layer structure of Vaults and Markets, along with an Adaptive Curve Interest Rate Model (IRM) for dynamic rate adjustment.
   * **Interest Rate Model:** users with a positive balance of the base asset earn interest, denominated in the base asset, based on a supply rate model.

--- a/docs/developers/resolving_contract_addresses.md
+++ b/docs/developers/resolving_contract_addresses.md
@@ -24,14 +24,14 @@ Every deployed-contract address uses the same three fields:
 
 ### jToken records
 
-For a network that exposes SBM markets, jTokens are keyed by symbol at `networks.<network>.jtokens.<symbol>`. A jToken record contains `symbol`, `status`, `underlying_symbol`, decimal metadata, and nested `delegator`, `delegate`, and `underlying` contract records. Native TRX has no TRC20 underlying address, so its `underlying` record contains a note instead.
+For a network that exposes SBM markets, jTokens are keyed by symbol at `networks.<network>.jtokens.<symbol>`. A jToken record contains `symbol`, `status`, `underlying_symbol`, decimal metadata, nested `delegator` and `underlying` records, and, when applicable, a `delegate` contract record. Native TRX has no TRC20 underlying address, so its `underlying` record contains a note instead.
 
 Filter `status === "active"` before directing new supply or borrow positions. Legacy markets remain queryable for unwinding existing positions but are closed to new supply and borrow.
 
 ### Example: resolve a jToken from its underlying symbol
 
 ```javascript
-import contracts from './contracts.json' assert { type: 'json' };
+import contracts from './contracts.json' with { type: 'json' };
 
 function jTokenForUnderlying(underlyingSymbol, network = 'mainnet') {
   const jtokens = contracts.networks?.[network]?.jtokens ?? {};
@@ -56,11 +56,11 @@ function jTokenForUnderlying(underlyingSymbol, network = 'mainnet') {
 console.log(jTokenForUnderlying('USDT'));
 ```
 
-The returned `underlyingAddress` is `null` for native TRX. Use the nested `delegator` address as the jToken address; the `delegate` address is the upgradeable implementation and is not the user-facing market address.
+The returned `underlyingAddress` is `null` for native TRX. Use the nested `delegator` address as the jToken address. When present, the `delegate` address is the upgradeable implementation and is not the user-facing market address.
 
 ## Live market data fallback
 
-Use the public market list (`GET https://openapi.just.network/lend/jtoken`, documented in [APIs §3.1](apis.md#31-get-lendjtoken-list-all-sbm-markets)) when you also need live rates, balances, prices, or collateral factors. Join the response with the registry by `jtokenAddress` or `underlyingAddress`; do not replace the registry's static contract addresses with an unverified API response.
+Use the public market list (`GET https://openapi.just.network/lend/jtoken`, documented in [APIs §3.1](apis.md#31-get-lendjtoken-list-all-sbm-markets)) when you also need live rates, balances, prices, or collateral factors. Join `response.data.tokenList[].address` with `networks.<network>.jtokens.*.delegator.address.base58`. For TRC20 markets, `underlyingAddress` can also be matched with `networks.<network>.jtokens.*.underlying.address.base58`; do not use this fallback for native TRX, whose API response uses the TRON zero address while the registry has no underlying address. Do not replace the registry's static contract addresses with an unverified API response.
 
 ## JustLend V2 (Moolah)
 

--- a/docs/developers/resolving_contract_addresses.md
+++ b/docs/developers/resolving_contract_addresses.md
@@ -1,0 +1,73 @@
+---
+title: Resolving Contract Addresses
+description: How to look up JustLend jToken and deployed-contract addresses from the machine-readable registry on TRON mainnet and Nile testnet.
+---
+
+# Resolving Contract Addresses
+
+!!! info "About this page"
+    **Protocol:** JustLend DAO · **Network:** TRON (Mainnet + Nile) · **Scope:** map human-facing symbols (`jUSDT`, `USDT`, and other contract labels) to on-chain Base58 and hexadecimal addresses without hard-coding them in an integration.
+
+## Machine-readable registry
+
+[`contracts.json`](contracts.json) is the canonical address registry. The root object contains a `networks` map, and each network contains optional contract categories such as `jtokens`, `comptroller`, `governance`, `strx`, and `interest_rate_models`.
+
+### Address formats
+
+Every deployed-contract address uses the same three fields:
+
+| Field | Use |
+|-------|-----|
+| `address.base58` | TRON Base58Check (`T…`) for wallets, Tronscan, and TronWeb |
+| `address.hex_evm` | EVM-style `0x…` address for ABI and cross-chain tooling |
+| `address.hex_tron` | TRON-internal `0x41…` address for low-level TronGrid/TronWeb calls |
+
+### jToken records
+
+For a network that exposes SBM markets, jTokens are keyed by symbol at `networks.<network>.jtokens.<symbol>`. A jToken record contains `symbol`, `status`, `underlying_symbol`, decimal metadata, and nested `delegator`, `delegate`, and `underlying` contract records. Native TRX has no TRC20 underlying address, so its `underlying` record contains a note instead.
+
+Filter `status === "active"` before directing new supply or borrow positions. Legacy markets remain queryable for unwinding existing positions but are closed to new supply and borrow.
+
+### Example: resolve a jToken from its underlying symbol
+
+```javascript
+import contracts from './contracts.json' assert { type: 'json' };
+
+function jTokenForUnderlying(underlyingSymbol, network = 'mainnet') {
+  const jtokens = contracts.networks?.[network]?.jtokens ?? {};
+  const jtoken = Object.values(jtokens).find(
+    (entry) =>
+      entry.underlying_symbol === underlyingSymbol &&
+      entry.status === 'active'
+  );
+
+  if (!jtoken) {
+    throw new Error(`No active jToken for ${underlyingSymbol} on ${network}`);
+  }
+
+  return {
+    symbol: jtoken.symbol,
+    jTokenAddress: jtoken.delegator.address.base58,
+    jTokenHex: jtoken.delegator.address.hex_tron,
+    underlyingAddress: jtoken.underlying?.address?.base58 ?? null,
+  };
+}
+
+console.log(jTokenForUnderlying('USDT'));
+```
+
+The returned `underlyingAddress` is `null` for native TRX. Use the nested `delegator` address as the jToken address; the `delegate` address is the upgradeable implementation and is not the user-facing market address.
+
+## Live market data fallback
+
+Use the public market list (`GET https://openapi.just.network/lend/jtoken`, documented in [APIs §3.1](apis.md#31-get-lendjtoken-list-all-sbm-markets)) when you also need live rates, balances, prices, or collateral factors. Join the response with the registry by `jtokenAddress` or `underlyingAddress`; do not replace the registry's static contract addresses with an unverified API response.
+
+## JustLend V2 (Moolah)
+
+The current `contracts.json` registry is for deployed protocol contracts and SBM jTokens; it does not enumerate the live Moolah vault and isolated-market catalog. Resolve those identifiers through the documented V2 read endpoints in [APIs §3.4](apis.md#34-justlend-v2-moolah-read-endpoints), then use the returned `vaultAddress` or market `id` when constructing requests.
+
+## Related pages
+
+- [Contracts Overview](contracts_overview.md)
+- [Common Pitfalls](common_pitfalls.md)
+- [MCP Server](../ai_support/mcp_server.md)

--- a/docs/developers/resolving_contract_addresses.md
+++ b/docs/developers/resolving_contract_addresses.md
@@ -10,7 +10,7 @@ description: How to look up JustLend jToken and deployed-contract addresses from
 
 ## Machine-readable registry
 
-[`contracts.json`](contracts.json) is the canonical address registry. The root object contains a `networks` map, and each network contains optional contract categories such as `jtokens`, `comptroller`, `governance`, `strx`, and `interest_rate_models`.
+[`contracts.json`](contracts.json) is the published machine-readable address registry, generated from the MCP server's [`src/core/chains.ts`](https://github.com/justlend/mcp-server-justlend/blob/main/src/core/chains.ts). Before consuming it, check `_meta.last_generated` and `_meta.schema_version` for freshness and schema compatibility. The root object contains a `networks` map, and each network contains optional contract categories such as `jtokens`, `comptroller`, `governance`, `strx`, and `interest_rate_models`.
 
 ### Address formats
 

--- a/docs/developers/staked_trx.md
+++ b/docs/developers/staked_trx.md
@@ -10,7 +10,7 @@ description: JustLend DAO sTRX liquid-staking contract reference — exchangeRat
     * **Network:** TRON Mainnet
     * **Contract:** [`TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5`](https://tronscan.org/#/token20/TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5) (immutable, replaced on protocol upgrade)
     * **Units:** Prices are denominated in **TRX** , scaled by `1e^(33 - tokenDecimal)`; sTRX is an 18-decimal TRC20; `exchangeRate()` is scaled by `1e18`, always ≥ 1, grows monotonically as rewards accrue.
-    * **Unbonding:** 14-day queue on JustLend, or instant exit via SunSwap / HTX
+    * **Unbonding:** 14-day queue on JustLend
     * **User-side overview:** [Staked TRX concept](../getting_started/concepts/staked_trx.md)
     * **ABI:** [`abis/strx.json`](abis/strx.json).
 

--- a/docs/getting_started/concepts/staked_trx.md
+++ b/docs/getting_started/concepts/staked_trx.md
@@ -6,7 +6,7 @@ description: Liquid staking for TRX under TRON Stake 2.0 — deposit TRX, receiv
 # Staked TRX
 
 !!! info "About this page"
-    **Protocol:** JustLend DAO sTRX (one-click liquid staking on TRON Stake 2.0) · **Network:** TRON Mainnet · **sTRX contract:** `TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5` (see [Deployed Contracts](../../developers/deployed_contracts.md#staked-trx)) · **Yield sources:** Super Representative voting rewards + Energy Rental revenue · **Units:** TRX amounts that cross a contract boundary are in **sun** (1 TRX = 10⁶ sun; see [Glossary → sun](../../resources/glossary.md#sun)). The exchange rate `sTRX → TRX` is scaled by `1e18`, always ≥ 1, grows over time as rewards accrue. TRX uses 6 decimals; sTRX is a standard TRC20 (also displayed with 18-decimal math by some clients — check the live exchange rate). · **Exit:** 14-day unbonding queue on JustLend, or instant swap on SunSwap / HTX.
+    **Protocol:** JustLend DAO sTRX (one-click liquid staking on TRON Stake 2.0) · **Network:** TRON Mainnet · **sTRX contract:** `TU3kjFuhtEo42tsCBtfYUAZxoqQ4yuSLQ5` (see [Deployed Contracts](../../developers/deployed_contracts.md#staked-trx)) · **Yield sources:** Super Representative voting rewards + Energy Rental revenue · **Units:** TRX amounts that cross a contract boundary are in **sun** (1 TRX = 10⁶ sun; see [Glossary → sun](../../resources/glossary.md#sun)). The exchange rate `sTRX → TRX` is scaled by `1e18`, always ≥ 1, grows over time as rewards accrue. TRX uses 6 decimals; sTRX is a standard TRC20 (also displayed with 18-decimal math by some clients — check the live exchange rate). · **Exit:** 14-day unbonding queue on JustLend.
 
 Staked TRX is a feature launched by JustLend DAO that enables one-click TRX staking in accordance with Stake 2.0 rules. Once you have staked your TRX, JustLend DAO will take care of the cumbersome procedures, such as Super Representative (SR) voting and reward claiming, and rent out the Energy obtained from TRX staking automatically to generate more yields for you.
 
@@ -46,7 +46,6 @@ The staking APY fluctuates with the changes in voting rewards and the Energy ren
 
 * **Unstake TRX:**
     * Unstake on JustLend DAO: Click the 「unstake」 tab, enter the amount of sTRX you want to unstake, and then confirm the transaction;
-    * Unstake via a third-party platform: You can initiate transactions on other platforms, such as HTX and SunSwap, to swap your sTRX.
 
 If you unstake your sTRX on JustLend DAO, you need to wait for 14 days before withdrawing the unstaked TRX by clicking 「Withdraw」 on the same page.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -100,7 +100,7 @@ One-click TRX liquid staking under Stake 2.0:
 - Deposit TRX into the sTRX contract → receive sTRX at the current exchange rate (1 sTRX ≥ 1 TRX, the ratio grows over time as rewards accrue).
 - sTRX is a standard TRC20 token and can be used in other TRON DeFi.
 - Yield sources: (1) Super Representative voting rewards, (2) Energy Rental revenue.
-- **Unstaking on JustLend has a 14-day unbonding period** before the underlying TRX can be claimed. Alternatively swap sTRX on a third-party DEX (SunSwap, HTX) for instant exit.
+- **Unstaking on JustLend has a 14-day unbonding period** before the underlying TRX can be claimed.
 
 ### 2.8 Energy Rental
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
         - Staked TRX: developers/staked_trx.md
         - Energy Rental: developers/energy_rental.md
         - Deployed Contracts: developers/deployed_contracts.md
+        - Resolving Contract Addresses: developers/resolving_contract_addresses.md
         - APIs: developers/apis.md
         - ABI Files: developers/abis/index.md
         - Common Pitfalls: developers/common_pitfalls.md


### PR DESCRIPTION
## Summary

- Add a contract-address resolution guide that matches the nested `contracts.json` schema.
- Document Base58, EVM-hex, and TRON-internal address formats with a working jToken lookup example.
- Clarify that Moolah vault and isolated-market identifiers come from the V2 API rather than the static registry.
- Remove the third-party exchange references from the user-facing and generated sTRX documentation.

## Validation

- `mkdocs build --strict --site-dir /tmp/justlend-docs-site`
- Node smoke test for USDT and native TRX jToken resolution
